### PR TITLE
Add clustertriggerauthentications permission

### DIFF
--- a/keda/templates/10-keda-clusterrole.yaml
+++ b/keda/templates/10-keda-clusterrole.yaml
@@ -81,6 +81,8 @@ rules:
 - apiGroups:
   - keda.sh
   resources:
+  - clustertriggerauthentications
+  - clustertriggerauthentications/status
   - triggerauthentications
   - triggerauthentications/status
   verbs:


### PR DESCRIPTION
Signed-off-by: Maksym Lushpenko iviakciivi@gmail.com

Fixes:
```
E0226 16:52:52.471183       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1alpha1.ClusterTriggerAuthentication: failed to list *v1alpha1.ClusterTriggerAuthentication: clustertriggerauthentications.keda.sh is forbidden: User "system:serviceaccount:kube-system:keda-operator" cannot list resource "clustertriggerauthentications" in API group "keda.sh" at the cluster scope
```

P.S. I haven't tested but seems self-explanatory, maybe you have some tests in CI

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md
-->
